### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ version = "0.4.1"
 
 [dependencies]
 clap = "2"
-getset = "0"
+getset = "0.1"
 serde = "1"
 serde_derive = "1"
-toml = "0"
+toml = "0.5"
 
 [dev-dependencies]
 dirs = "1"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.